### PR TITLE
device endpoint needed also client auth

### DIFF
--- a/src/pam_oauth2_device.py
+++ b/src/pam_oauth2_device.py
@@ -44,6 +44,9 @@ def load_config(file_name):
 def make_authorization_request(config):
     device_response = requests.post(
         config['oauth']['device_endpoint'],
+        auth=(
+            config['oauth']['client']['id'],
+            config['oauth']['client']['secret']),
         data={
             'client_id': config['oauth']['client']['id'],
             'scope': ' '.join(config['oauth']['scope'])


### PR DESCRIPTION
The client authentication requirements of Section 3.2.1 of [RFC6749]
apply to requests on this endpoint, which means that confidential
clients (those that have established client credentials) authenticate
in the same manner as when making requests to the token endpoint, and
public clients provide the "client_id" parameter to identify
themselves."