### PR TITLE
Log unsuccessful username mapping

### DIFF
--- a/src/pam_oauth2_device.cpp
+++ b/src/pam_oauth2_device.cpp
@@ -383,6 +383,7 @@ bool is_authorized(Config *config,
         }
         delete[] filter;
     }
+    syslog(LOG_ERR, "cannot find mapping between user %s and local account %s", username_remote, username_local);
     return false;
 }
 


### PR DESCRIPTION
When the mapping is not found or is wrong, log warn message.