### PR TITLE
feat(QR): add configuration option to disable QR code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,17 @@ See `config_template.json` (LDAP section is optional).
 
 Edit `/etc/pam_oauth2_device/config.json`.
 
-**qr** - allowed correction levels are
-
-- 0 - low
-- 1 - medium
-- 2 - high
-
-**users** - user mapping. From claim configured in _username_attribute_
-to the local account name
-
-**MFA** - under the **oauth** block, via setting `"require_mfa": true`,
-the module will modify the requests to ask user to perform the MFA.
-For more info on the exact form, see the `config_template.json` file.
+- `qr` QR code encodes the authentication URL.
+  - `show`: show (`true`, default) or hide (`false`) the QR code
+  - `error_correction_level`: allowed correction levels are
+    - 0 - low
+    - 1 - medium
+    - 2 - high
+- `users` User mapping from claim configured in _username_attribute_
+  to the local account name.
+- `oauth` configuration for the OIDC identity provider.
+  - `require_mfa`: if `true` the module will modify the requests to ask
+    user to perform the MFA.
 
 ### Example Configuration for sshd
 

--- a/config_template.json
+++ b/config_template.json
@@ -5,15 +5,14 @@
             "secret": "client_secret"
         },
         "scope": "openid profile",
-        "device_endpoint":"https://provider.com/devicecode", 
+        "device_endpoint": "https://provider.com/devicecode",
         "token_endpoint": "https://provider.com/token",
         "userinfo_endpoint": "https://provider.com/userinfo",
         "username_attribute": "preferred_username",
         "require_mfa": false
     },
     "ldap": {
-        "hosts":
-        [
+        "hosts": [
             "ldaps://ldap-server1:636",
             "ldaps://ldap-server2:636",
             "ldaps://ldap-server3:636"
@@ -25,16 +24,15 @@
         "attr": "uid"
     },
     "qr": {
+        "show": true,
         "error_correction_level": 0
     },
     "users": {
-        "provider_user_id_1":
-        [
+        "provider_user_id_1": [
             "root",
             "bob"
         ],
-        "provider_user_id_2":
-        [
+        "provider_user_id_2": [
             "mike"
         ]
     }

--- a/src/include/config.cpp
+++ b/src/include/config.cpp
@@ -22,6 +22,8 @@ void Config::load(const char *path) {
       j.at("oauth").at("username_attribute").get<std::string>();
   qr_error_correction_level =
       j.at("qr").at("error_correction_level").get<int>();
+  qr_show =
+      (j["qr"].contains("show")) ? j.at("qr").at("show").get<bool>() : true;
   if (j.find("ldap") != j.end() && j["ldap"].find("hosts") != j["ldap"].end()) {
     for (auto &host : j["ldap"]["hosts"]) {
       ldap_hosts.insert((std::string)host);

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -11,7 +11,7 @@ class Config {
   std::string client_id, client_secret, scope, device_endpoint, token_endpoint,
       userinfo_endpoint, username_attribute, ldap_basedn, ldap_user,
       ldap_passwd, ldap_filter, ldap_attr;
-  bool request_mfa;
+  bool request_mfa, qr_show;
   std::set<std::string> ldap_hosts;
   int qr_error_correction_level;
   std::map<std::string, std::set<std::string>> usermap;

--- a/src/pam_oauth2_device.hpp
+++ b/src/pam_oauth2_device.hpp
@@ -12,7 +12,7 @@ class DeviceAuthResponse {
  public:
   std::string user_code, verification_uri, verification_uri_complete,
       device_code;
-  std::string get_prompt(const int qr_ecc);
+  std::string get_prompt(const int qr_ecc, const bool qr_show);
 };
 
 void make_authorization_request(const char *client_id,


### PR DESCRIPTION
QR code can now be disabled from the configuration.
Additionally, the QR code is now displayed before the
authentication URL which should improve UX on the default
80x24 terminal size.

Closes #14