### PR TITLE
test: ignore error about header files without dir

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,2 +1,2 @@
 set noparent
-filter=-legal/copyright,-build/c++11,-build/header_guard
+filter=-legal/copyright,-build/c++11,-build/header_guard,-build/include_subdir


### PR DESCRIPTION
cpplint complains about # "include" should use the new style "foo/bar.h" instead of just "bar.h". Not all header files must be under the directory, see https://github.com/cpplint/cpplint/issues/8.